### PR TITLE
outcomes-hawk needs to be able to use the KMS key used to encrypt CT Events

### DIFF
--- a/cloud_defender/cloudDefender-cross-account-iam-role(centralized_cloudtrail_account).yaml
+++ b/cloud_defender/cloudDefender-cross-account-iam-role(centralized_cloudtrail_account).yaml
@@ -25,11 +25,20 @@ Parameters:
     MaxLength: 1224
     Type: String
     NoEcho: 'true'
+  KMSKey:
+    Description: ARN of the KMS key used to encrypt the CloudTrail
+    Type: String
+    Default: ''    
 Mappings:
   AlertLogic:
     Datacenter:
       US: 'arn:aws:iam::733251395267:root'
       EU: 'arn:aws:iam::857795874556:root'
+Conditions:
+  NoKMS: !Equals
+    - ''
+    - !Ref KMSKey
+
 Resources:
   AlertLogicRole:
     Properties:
@@ -85,6 +94,10 @@ Resources:
                   - 's3:GetBucketLocation'
                   - 's3:GetObject'
                 Resource: '*'
+              - Sid: AllowDecryptOfCloudTrailKey
+                Effect: !If [NoKMS, 'Deny', 'Allow']
+                Action: kms:Decrypt
+                Resource: !If [NoKMS, 'arn:aws:kms:*:*:*', !Ref KMSKey]                
               - Sid: CreateCloudTrailsTopicTfOneWasntAlreadySetupForCloudTrails
                 Effect: Allow
                 Action:


### PR DESCRIPTION
AlertLogic,

Attempting to review some alarms and I discovered that the template provided doesn't grant decryption if the the CloudTrail is using a KMS Key. I believe this PR resolves that, however I don't have a method to trigger the outcomes-hawk. 

thanks