### PR TITLE
Allow Customer to set the name of their SQS Queue

### DIFF
--- a/log_manager/logmanager-cloudtrail-collection-setup_v1.2.yaml
+++ b/log_manager/logmanager-cloudtrail-collection-setup_v1.2.yaml
@@ -40,6 +40,12 @@ Parameters:
       ARN of an existing CloudTrail topic to subscribe SQS to. Create the stack
       in the region where the SNS Topic exists.
     Type: String
+  QueueName:
+    Description: >-
+      Name of the SQS Queue to create. CloudTrail's SNS Topic will Send Messages
+      to this Queue and LogManager will Receive Messages from it. .
+    Type: String
+    Default: alertlogic-cloudtrail-sqs-queue
   KMSKey:
     Description: ARN of the KMS key used to encrypt the CloudTrail
     Type: String
@@ -143,7 +149,7 @@ Resources:
   CloudTrailSQSQueue:
     Type: 'AWS::SQS::Queue'
     Properties:
-      QueueName: alertlogic-cloudtrail-sqs-queue
+      QueueName: !Ref QueueName
   CloudTrailSQSQueuePolicy:
     Type: 'AWS::SQS::QueuePolicy'
     DependsOn:


### PR DESCRIPTION
Needed this to get around the Pending Confirmation problem before AWS's natural timeout. 