### PR TITLE
workaround in KMS use-case where Cloud Explorer reject explicit Deny

### DIFF
--- a/cloud_defender/cloudDefender-cross-account-iam-role(centralized_cloudtrail_account).yaml
+++ b/cloud_defender/cloudDefender-cross-account-iam-role(centralized_cloudtrail_account).yaml
@@ -28,7 +28,7 @@ Parameters:
   KMSKey:
     Description: ARN of the KMS key used to encrypt the CloudTrail
     Type: String
-    Default: ''    
+    Default: ''
 Mappings:
   AlertLogic:
     Datacenter:
@@ -51,7 +51,7 @@ Resources:
             Effect: Allow
             Principal:
               AWS:
-                - !FindInMap 
+                - !FindInMap
                   - AlertLogic
                   - Datacenter
                   - !Ref AlertLogicDatacenter
@@ -95,9 +95,9 @@ Resources:
                   - 's3:GetObject'
                 Resource: '*'
               - Sid: AllowDecryptOfCloudTrailKey
-                Effect: !If [NoKMS, 'Deny', 'Allow']
+                Effect: Allow
                 Action: kms:Decrypt
-                Resource: !If [NoKMS, 'arn:aws:kms:*:*:*', !Ref KMSKey]                
+                Resource: !If [NoKMS, 'arn:aws:kms:*:*:key/nonexistent-key', !Ref KMSKey]
               - Sid: CreateCloudTrailsTopicTfOneWasntAlreadySetupForCloudTrails
                 Effect: Allow
                 Action:
@@ -126,6 +126,6 @@ Outputs:
     Value: !Ref ExternalID
   RoleARN:
     Description: Amazon Resource Name of your new Cross-Account IAM Role.
-    Value: !GetAtt 
+    Value: !GetAtt
       - AlertLogicRole
       - Arn

--- a/cloud_defender/cloudDefender-cross-account-iam-role(protected_account).yaml
+++ b/cloud_defender/cloudDefender-cross-account-iam-role(protected_account).yaml
@@ -23,11 +23,19 @@ Parameters:
     MaxLength: 1224
     Type: String
     NoEcho: 'true'
+  KMSKey:
+    Description: ARN of the KMS key used to encrypt the CloudTrail. If you are use centralized CloudTrail, enter the KMS key on the Receiving CFT instead of in this CFT.
+    Type: String
+    Default: ''
 Mappings:
   AlertLogic:
     Datacenter:
       US: 'arn:aws:iam::733251395267:root'
       EU: 'arn:aws:iam::857795874556:root'
+Conditions:
+  NoKMS: !Equals
+    - ''
+    - !Ref KMSKey
 Resources:
   AlertLogicRole:
     Properties:
@@ -40,7 +48,7 @@ Resources:
             Effect: Allow
             Principal:
               AWS:
-                - !FindInMap 
+                - !FindInMap
                   - AlertLogic
                   - Datacenter
                   - !Ref AlertLogicDatacenter
@@ -115,6 +123,10 @@ Resources:
                   - 'sqs:DeleteMessage'
                   - 'sqs:GetQueueUrl'
                 Resource: 'arn:aws:sqs:*:*:outcomesbucket*'
+              - Sid: AllowDecryptOfCloudTrailKey
+                Effect: Allow
+                Action: kms:Decrypt
+                Resource: !If [NoKMS, 'arn:aws:kms:*:*:key/nonexistent-key', !Ref KMSKey]
             Version: 2012-10-17
           PolicyName: alertlogic-clouddefender-iam-policy
     Type: 'AWS::IAM::Role'
@@ -124,6 +136,6 @@ Outputs:
     Value: !Ref ExternalID
   RoleARN:
     Description: Amazon Resource Name of your new Cross-Account IAM Role.
-    Value: !GetAtt 
+    Value: !GetAtt
       - AlertLogicRole
       - Arn


### PR DESCRIPTION
when you enter the IAM role ARN via UI, Cloud Explorer will validate and reject any explicit Deny.
as a workaround, KMS:Decrypt permission will always set to Allow, with non-existent key specified when there's no KMS encrypted CloudTrail.

