### PR TITLE
Prevent update replacement when changing security group

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,23 +6,20 @@ This group of CloudFormation templates have been designed to allow Alert Logic u
 
 ```
 ├── cloud_defender
-│   ├── cloudDefender_auto-claim_v3(uk).yaml
-│   ├── cloudDefender_auto-claim_v3(us).yaml
 │   ├── cloudDefender-cross-account-iam-role(centralized_cloudtrail_account).yaml
 │   └── cloudDefender-cross-account-iam-role(protected_account).yaml
 ├── cloud_insight
 │   ├── cloudinsight-cross-account-iam-role(centralized_cloudtrail_account).yaml
 │   ├── cloudinsight-cross-account-iam-role(protected_account).yaml
 │   └── cloudinsight-essentials-cross-account-iam-role(protected_account).yaml
+├── LICENSE
 ├── log_manager
+│   ├── al_lm_cloudtrail-collection-setup.yaml
+│   ├── al_lm_s3-collection-setup.yaml
 │   ├── clw-to-s3-child-nested.yaml
-│   ├── clw-to-s3-master.yaml
-│   ├── logmanager-cloudtrail-collection-setup_v1.2.yaml
-│   └── logmanager-s3-collection-setup_v1.1.yaml
+│   └── clw-to-s3-master.yaml
+├── README.md
 └── threat_manager
-    ├── tmc_auto-claim_v3(uk).yaml
-    ├── tmc_auto-claim_v3(us).yaml
-    └── tmc_us-gov_v3.yaml
+    └── al_tmc_auto-claim.yaml
 
-4 directories, 14 files
 ```

--- a/threat_manager/al_tmc_auto-claim.yaml
+++ b/threat_manager/al_tmc_auto-claim.yaml
@@ -179,20 +179,13 @@ Resources:
         - !Ref 'AWS::Region'
         - AMI
       InstanceType: !Ref instanceType
-      NetworkInterfaces:
-        - GroupSet:
-            - !Ref sgThreatManager
-            - !If
-              - AddWebAppIDSRules
-              - !Ref sgWebAppIDS
-              - !Ref sgThreatManager
-          AssociatePublicIpAddress: !If
-            - AttachEIP
-            - 'true'
-            - 'false'
-          DeviceIndex: '0'
-          DeleteOnTermination: 'true'
-          SubnetId: !Ref subnetId
+      SubnetId: !Ref subnetId
+      SecurityGroupIds:
+        - !Ref sgThreatManager
+        - !If
+          - AddWebAppIDSRules
+          - !Ref sgWebAppIDS
+          - !Ref sgThreatManager
       Tags:
         - Key: Name
           Value: Alert Logic Threat Manager
@@ -216,3 +209,8 @@ Outputs:
     Description: >-
       Add this Security Group ID into the destination fields of the egress
       rules for the Agents' Security Groups.
+  appliancePublicIP:
+    Value: !Ref tmcEIP
+    Description: >-
+      Monitor appliance claim status from http://[appliancePublicIP].
+    Condition: AttachEIP

--- a/threat_manager/al_tmc_auto-claim.yaml
+++ b/threat_manager/al_tmc_auto-claim.yaml
@@ -181,11 +181,11 @@ Resources:
       InstanceType: !Ref instanceType
       SubnetId: !Ref subnetId
       SecurityGroupIds:
-        - !Ref sgThreatManager
-        - !If
+        !If
           - AddWebAppIDSRules
-          - !Ref sgWebAppIDS
-          - !Ref sgThreatManager
+          - - !Ref sgWebAppIDS
+            - !Ref sgThreatManager
+          - - !Ref sgThreatManager
       Tags:
         - Key: Name
           Value: Alert Logic Threat Manager


### PR DESCRIPTION
Changes:
1. Use SecurityGroupIds to avoid update replacement when you have AddWebAppIDSRules condition set to true
2. Update file tree in readme 